### PR TITLE
Fix carrousell not displaying all photos

### DIFF
--- a/app/Models/District.php
+++ b/app/Models/District.php
@@ -74,7 +74,7 @@ class District extends Model
     {
         $type = Type::findByType($type)->pluck('id');
         $ids = Type::where('type_id', $type)->pluck('id');
-        
+
         $services = DB::table('services')
             ->selectRaw('services.*')
             ->join('addresses', 'services.id', 'addresses.addressable_id')
@@ -84,12 +84,26 @@ class District extends Model
             ->where('districts.id', $this->id)
             ->where('addressable_type', 'App\\Models\\Service')
             ->pluck('id');
-        
+
         return Service::find($services);
     }
 
     public function image()
     {
         return $this->morphOne(Image::class, 'imageable');
+    }
+
+    public function getImagesAttribute()
+    {
+        $images_path = collect(
+            $this
+                ->hasManyThrough(Image::class, City::class, null, 'imageable_id')
+                ->where('imageable_type', 'App\\Models\\City')
+                ->get()
+        )->map(function ($image) {
+            return 'storage/' . $image->path;
+        });
+
+        return $images_path;
     }
 }

--- a/resources/views/web/about.blade.php
+++ b/resources/views/web/about.blade.php
@@ -23,10 +23,14 @@
 @section('scripts')
 <script src="{{ asset('js/carrusel.js') }}"></script>
     <script>
-        /*const images = {!! findAll($district->addresses->where('addressable_type', 'App\\Models\\Location')->pluck('addressable_id'), 'App\\Models\\Location') !!};*/
-
         const images = [];
-        images.push("{!! $district->image->path !!}");
+        
+        @forelse($district->images as $image)
+            images.push("{!! $image !!}");
+        @empty
+            images.push("img/no-image.png");
+        @endforelse
+        
         
         carrusel(images);
     </script>

--- a/resources/views/web/district.blade.php
+++ b/resources/views/web/district.blade.php
@@ -79,6 +79,7 @@
     <script src="{{ asset('js/carrusel.js') }}"></script>
     <script>
         const images = [];
+        
         @forelse($district->images as $image)
             images.push("{!! $image !!}");
         @empty

--- a/resources/views/web/district.blade.php
+++ b/resources/views/web/district.blade.php
@@ -79,7 +79,11 @@
     <script src="{{ asset('js/carrusel.js') }}"></script>
     <script>
         const images = [];
-        images.push("{!! $district->image ? 'storage/'.$district->image->path : 'img/no-image.png' !!}");
+        @forelse($district->images as $image)
+            images.push("{!! $image !!}");
+        @empty
+            images.push("img/no-image.png");
+        @endforelse
         
         carrusel(images);
     </script>


### PR DESCRIPTION
Needs to be fixed on frontend side. These are problems i encountered:

- Images are loading through a script: i think it will be easier if images where loaded in the html and the javascript only take care of the behavior.
- Images are not displaying properly: i've checked that the backend was passing the right images but not only are the photos cropped but also, when moving to the next or previous (through click or time), it doesn't show the next image, just the "next part" of the current image.

Screenshots of three different images on the same slider (there we're totally different images)
![image](https://user-images.githubusercontent.com/23386396/116310052-e3d4ee80-a77f-11eb-9a69-6f937b40d064.png)
![image](https://user-images.githubusercontent.com/23386396/116310192-10890600-a780-11eb-8c25-31efb743967f.png)
![image](https://user-images.githubusercontent.com/23386396/116310208-14b52380-a780-11eb-8bdd-3ec8f94eff46.png)

If you do work on this, please do it on this same branch.
`git checkout master`
`git pull`
`git pull origin fix_carrousell_not_displaying_all_photos`
`git checkout fix_carrousell_not_displaying_all_photos`